### PR TITLE
Fix global menu popping down on landscape tablet size

### DIFF
--- a/stylesheets/full-stylesheet.css
+++ b/stylesheets/full-stylesheet.css
@@ -1073,7 +1073,6 @@ caption{background:#fff;padding:5px 0}
 	/*Change main nav*/
 	.campl-global-navigation{width:280px}
 	.campl-global-navigation li{width:33%}
-	.campl-global-navigation li a{padding:25px 10px}
 	.campl-header-container{width:auto;float:left}
 }
 
@@ -1096,9 +1095,10 @@ caption{background:#fff;padding:5px 0}
 
 
 /* tablet landscape */
-@media only screen and (max-width: 1024px){
+@media only screen and (max-width: 1150px){
 
 	.campl-site-search {padding-right:15px}
+	.campl-global-navigation li a{padding:25px 10px}
 
 	.campl-pagination a, .campl-elipsis{padding: 8px 15px;line-height: 20px;}
 	


### PR DESCRIPTION
This fix is already in use on www.cam.ac.uk.
