### PR TITLE
Make parent items in the horizontal navigation clickable

### DIFF
--- a/components/core-elements/index.html
+++ b/components/core-elements/index.html
@@ -87,7 +87,7 @@
 						</ul>
 						
 						<p>To view a demonstration of the local navigation in full please navigate through the following path, starting <a href="local-navigation-01.html">from this page</a>:</p>
-						<p>Faculty of MML > Departments overview > French > French in the MML tripos > Year 1. </p>
+						<p>Faculty of MML > Departments > French > French in the MML tripos > Year 1. </p>
 						<h3 id="page-layouts">Page layouts</h3>
 						<p>For guidelines on using these layout variants see <a href="../../template-variants/index.html">Page templates</a>.
 						<ul class="campl-unstyled-list styleguide-menu ">

--- a/components/core-elements/local-navigation-01.html
+++ b/components/core-elements/local-navigation-01.html
@@ -59,12 +59,10 @@
 			<div class="campl-local-navigation-container">
 				<ul class="campl-unstyled-list">
 					<li><a href="#">About the Faculty</a></li>
-					<li><a href="">Departments</a>
+					<li><a href="local-navigation-02.html">Departments</a>
 						<ul class="campl-unstyled-list">
-							<li><a href="local-navigation-02.html">Departments overview</a>
 							<li><a href="local-navigation-03.html">French</a>
 								<ul class="campl-unstyled-list">
-									<li><a href="local-navigation-03.html">French overview</a>
 									<li><a href="local-navigation-04.html">French in the MML Tripos</a>
 										<ul class="campl-unstyled-list">
 											<li><a href="local-navigation-05.html">Year 1</a>

--- a/components/core-elements/local-navigation-02.html
+++ b/components/core-elements/local-navigation-02.html
@@ -62,12 +62,10 @@
 			<div class="campl-local-navigation-container">
 					<ul class="campl-unstyled-list">
 						<li><a href="#">About the Faculty</a></li>
-						<li><a href="" class="campl-selected">Departments</a>
+						<li><a href="local-navigation-02.html" class="campl-selected">Departments</a>
 							<ul class="campl-unstyled-list">
-								<li class="campl-current-page"><a href="local-navigation-02.html">Departments overview</a>
 								<li><a href="local-navigation-03.html">French</a>
 									<ul class="campl-unstyled-list">
-										<li><a href="local-navigation-03.html">French overview</a>
 										<li><a href="local-navigation-04.html">French in the MML Tripos</a>
 											<ul class="campl-unstyled-list">
 												<li><a href="local-navigation-05.html">Year 1</a>
@@ -130,9 +128,8 @@
 							<li><a href="local-navigation-01.html">Faculty of Modern &amp; Medieval Languages <span class="campl-vertical-breadcrumb-indicator"></span></a></li>
 						</ul>	
 						<ul class="campl-unstyled-list campl-vertical-breadcrumb-navigation">	
-							<li class="campl-selected">Departments
+							<li class="campl-selected"><a href="local-navigation-02.html">Departments</a>
 								<ul class='campl-unstyled-list campl-vertical-breadcrumb-children'>
-									<li class="campl-selected"><a href="local-navigation-02.html">Departments overview</a></li>
 									<li><a href="local-navigation-03.html">French</a></li>
 									<li><a href="#">German and Dutch</a></li>
 									<li><a href="#">Italian</a></li>

--- a/components/core-elements/local-navigation-03.html
+++ b/components/core-elements/local-navigation-03.html
@@ -65,12 +65,10 @@
 			<div class="campl-local-navigation-container">
 				<ul class="campl-unstyled-list">
 					<li><a href="#">About the Faculty</a></li>
-					<li><a href="" class="campl-selected">Departments</a>
+					<li><a href="local-navigation-02.html" class="campl-selected">Departments</a>
 						<ul class="campl-unstyled-list">
-							<li><a href="local-navigation-02.html">Departments overview</a>
 							<li><a href="local-navigation-03.html">French</a>
 								<ul class="campl-unstyled-list">
-									<li class="campl-current-page"><a href="local-navigation-03.html">French overview</a>
 									<li><a href="local-navigation-04.html">French in the MML Tripos</a>
 										<ul class="campl-unstyled-list">
 											<li><a href="local-navigation-05.html">Year 1</a>
@@ -134,9 +132,8 @@
 							<li><a href="local-navigation-02.html">Departments <span class="campl-vertical-breadcrumb-indicator"></span></a></li>
 						</ul>	
 						<ul class="campl-unstyled-list campl-vertical-breadcrumb-navigation">	
-							<li class="campl-selected">French
+							<li class="campl-selected"><a href="local-navigation-03.html">French</a>
 								<ul class='campl-unstyled-list campl-vertical-breadcrumb-children'>
-									<li class='campl-selected'><a href="local-navigation-03.html">French overview</a></li>
 									<li><a href="local-navigation-05.html">French in the MML Tripos</a></li>
 									<li><a href="">Staff list</a>
 									<li><a href="">News and events</a>

--- a/components/core-elements/local-navigation-05.html
+++ b/components/core-elements/local-navigation-05.html
@@ -68,12 +68,10 @@
 			<div class="campl-local-navigation-container">
 				<ul class="campl-unstyled-list">
 					<li><a href="#">About the Faculty</a></li>
-					<li><a href="" class="campl-selected">Departments</a>
+					<li><a href="local-navigation-02.html" class="campl-selected">Departments</a>
 						<ul class="campl-unstyled-list">
-							<li><a href="local-navigation-02.html">Departments overview</a>
 							<li><a href="local-navigation-03.html">French</a>
 								<ul class="campl-unstyled-list">
-									<li><a href="local-navigation-03.html">French overview</a>
 									<li><a href="local-navigation-04.html">French in the MML Tripos</a>
 										<ul class="campl-unstyled-list">
 											<li class="campl-current-page"><a href="local-navigation-05.html">Year 1</a>

--- a/javascripts/custom.js
+++ b/javascripts/custom.js
@@ -489,15 +489,15 @@ projectlight.localNav=(function(){
 		
 		//Bound click event for all links inside the local navigation. 
 		//handles moving forwards and backwards through pages or opening dropdown menu
-		$links.click(function(e){
+		$links.find('span').click(function(e){
 			var $linkClicked = $(this),
-			$listItemClicked = $linkClicked.parent();
-			
+			$listItemClicked = $linkClicked.parent().parent();
+
 			if($listItemClicked.hasClass("campl-title") && Modernizr.mq('only screen and (max-width: 767px)')){
-				e.preventDefault();	
+				e.preventDefault();
 			}else{
-				if($listItemClicked.hasClass("campl-sub")){
-					//slide mobile or tablet menu forward 
+				if($listItemClicked.hasClass("campl-sub") && Modernizr.mq('only screen and (max-width: 767px)')){
+					//slide mobile or tablet menu forward
 					if(projectlight.mobileLayout){
 						slideMenu("forward");
 						$listItemClicked.addClass("campl-current")
@@ -510,19 +510,19 @@ projectlight.localNav=(function(){
 							showSubNavigation($linkClicked, e)
 						}
 					}
-				e.preventDefault();	
+				e.preventDefault();
 				}else{
 					if($listItemClicked.hasClass("campl-back-link")){
 						slideMenu("back");
+						$linkClicked.parent().parent().parent().parent().addClass("campl-previous");
 						$linkClicked.parent().parent().parent().addClass("campl-previous");
-						$linkClicked.parent().parent().addClass("campl-previous");
 						return false
 					}
 				}
 			}
-			
+
 		});
-		
+
 		//ensure dropdown or sliding panels are set to the correct width if the page changes and also on first load
 		$(window).resize(function(){
 			setMenuWidth();

--- a/stylesheets/full-stylesheet.css
+++ b/stylesheets/full-stylesheet.css
@@ -1304,10 +1304,11 @@ caption{background:#fff;padding:5px 0}
 
 	.js .campl-menu-btn{margin:0;display:block;}
 
-	.campl-menu-indicator{height:20px;width:20px;position:absolute;top:50%;left:10px;display:block;margin-top:-10px;border-radius:1px; -webkit-border-radius:1px;background-repeat:no-repeat;background-position:50% 50%}
-	.campl-fwd-btn{right:10px;left:auto;background-image:url(../images/interface/icon-fwd-btn.png) }
+	.campl-menu-indicator{height:48px;width:48px;position:absolute;top:0%;left:10px;display:block;margin-top:0px;border-radius:1px; -webkit-border-radius:1px;background-repeat:no-repeat;background-position:50% 50%}
+	.campl-back-link .campl-menu-indicator{height:20px;width:20px;position:absolute;top:50%;left:10px;display:block;margin-top:-10px;border-radius:1px; -webkit-border-radius:1px;background-repeat:no-repeat;background-position:50% 50%}
+	.campl-fwd-btn{right:0px;left:auto;background-image:url(../images/interface/icon-fwd-btn.png) }
 	.campl-back-btn{left:25px;background-image:url(../images/interface/icon-back-btn.png)}
-	
+
 	.js .campl-menu-btn span{padding:15px 0 15px 25px;display:block}
 	.js .campl-menu-btn a{padding:0;position:relative;}
 	.js .campl-menu-btn .campl-menu-btn-arrow{width:53px;height:53px;display:block;position:absolute;top:0;right:0;padding:0;background-repeat:no-repeat;background-position:50% 50%}


### PR DESCRIPTION
The horizontal navigation on www.cam.ac.uk was changed so that items that contain subitems are clickable (this is more noticeable on smaller screens where you now have to click/tap the arrow rather than the whole row to see the subitems).

I've updated the docs accordingly by removing the now-redundant 'Overview' links.
