### PR TITLE
footer.html: grammar fix: less -> fewer

### DIFF
--- a/components/core-elements/footer.html
+++ b/components/core-elements/footer.html
@@ -267,7 +267,7 @@
 						<hr />
 						<div class="campl-content-container">
 							<h4>Usage</h4>
-							<p>At mobile resolution the footer structures will be simplified to show less options for ease of scrolling.</p>
+							<p>At mobile resolution the footer structures will be simplified to show fewer options for ease of scrolling.</p>
 							<p>You can force a list to always be fully viewable at mobile resolution by adding the class "campl-page-children" to it (in the global footer, the About the University and Research at Cambridge lists have this applied).</p>
 							<hr /><h4>Interaction</h4>
 							<p>N/a</p>


### PR DESCRIPTION
The options in the footer are discrete and countable. There are, therefore, _fewer_ options shown on small screens and not _less_.
