### PR TITLE
Use .campl-heading-container consistently

### DIFF
--- a/stylesheets/full-stylesheet.css
+++ b/stylesheets/full-stylesheet.css
@@ -639,6 +639,7 @@ body{margin:0;padding:0; background:#000;width:100%;}
 
 /* Homepage Events highlight */
 .campl-highlight-event-item{border-top:1px solid #e4e4e4}
+.campl-highlight-event-item:first-child{border-top:none}
 .campl-highlight-date-container{width:55px;float:left;margin:0 10px 5px 0;}
 .campl-highlight-date{text-align:center;padding:0px 0 2px 0}
 .campl-highlight-day, .campl-highlight-event-link, .campl-highlight-date{display:block}

--- a/template-variants/event-landing.html
+++ b/template-variants/event-landing.html
@@ -451,7 +451,9 @@
 			</div>
 			<div class="campl-column3 campl-secondary-content campl-recessed-secondary-content">
 				<div class="campl-content-container">
-					<h2>What's on Sponsor</h2>
+					<div class="campl-heading-container">
+						<h2>What's on Sponsor</h2>
+					</div>
 					<img alt=""  src="../images/content/events-sponsor.png" class="campl-scale-with-grid" />
 				</div>
 				

--- a/template-variants/homepage.html
+++ b/template-variants/homepage.html
@@ -504,8 +504,10 @@
 						<li><a href="#">Term dates</a></li>
 					</ul>
 				</div>
-				<div class="campl-content-container">	
-					<h2>Highlight events</h2>
+				<div class="campl-content-container">
+					<div class="campl-heading-container">
+						<h2>Highlight events</h2>
+					</div>
 					<ul class='campl-unstyled-list highlight-events'>
 					
 						<li class="campl-highlight-event-item clearfix">


### PR DESCRIPTION
Most headings (not in the normal body content) are wrapped inside a `.campl-heading-container`, except for two places: "Highlight events" and "What's on sponsor".

With the former, adding it creates a double border:

![image](https://f.cloud.github.com/assets/1784740/1163220/7fd7c520-2036-11e3-89c4-ff1430b22ea4.png)

And with the latter it adds a line above the image:

![image](https://f.cloud.github.com/assets/1784740/1163223/8f470638-2036-11e3-84f0-401010cfa999.png)

It's awkward to implement these headers as it's not consistent. This change adds them in, and adds a CSS tweak to resolve the former (which is already in use on www.cam.ac.uk). It leaves the latter as above (doesn't seem like a problem to me!).
