### PR TITLE
Stop IE from using compatibility mode

### DIFF
--- a/components/core-elements/content-wrapping.html
+++ b/components/core-elements/content-wrapping.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,10 +25,19 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
 
-		
-		
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
+
+
 		<div class="campl-row styleguide-notes">
 			<div class="campl-wrap clearfix">
 				<div class="campl-content-container">
@@ -84,7 +91,12 @@
 					</div>
 				</div>
 			</div>
-		</div>	
+		</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/footer.html
+++ b/components/core-elements/footer.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -29,6 +27,17 @@
 	<!-- <script type="text/javascript" src='http://getfirebug.com/releases/lite/1.2/firebug-lite-compressed.js'></script>-->
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-local-footer">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
@@ -288,9 +297,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/form-elements.html
+++ b/components/core-elements/form-elements.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 <div class="campl-row campl-content">
 	<div class="campl-wrap clearfix">
 		<div class="campl-column3">
@@ -345,7 +354,11 @@
 			</div>
 		</div>
 	</div>
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../..javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/global-header.html
+++ b/components/core-elements/global-header.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
@@ -320,12 +328,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
-	
-	
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/grid.html
+++ b/components/core-elements/grid.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,7 +26,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">	
@@ -435,7 +442,10 @@
 		</div>
 	</div>
 
-	
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/homepage-header.html
+++ b/components/core-elements/homepage-header.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-homepage-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
@@ -267,8 +276,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/image-handling.html
+++ b/components/core-elements/image-handling.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -29,6 +27,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3">
@@ -190,7 +199,10 @@
 		</div>
 	</div>
 
-	
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/index.html
+++ b/components/core-elements/index.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="styleguide">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
@@ -135,6 +144,11 @@
 		</div>
 	</div>
 </div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script src="../../javascripts/libs/jquery-min.js"></script>
 	<script src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/link-styles.html
+++ b/components/core-elements/link-styles.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,7 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
  	<div class="campl-row campl-content ">
 		<div class="campl-wrap clearfix">
 			<div class="campl-content-container">
@@ -134,7 +142,12 @@
 					</div>
 				</div>
 			</div>
-		</div>	
+		</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/list-types.html
+++ b/components/core-elements/list-types.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
@@ -131,6 +139,10 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/local-navigation-01.html
+++ b/components/core-elements/local-navigation-01.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,7 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-page-header global-page">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column12">
@@ -146,7 +154,10 @@
 		</div>	
 	</div>
 
-	
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/local-navigation-02.html
+++ b/components/core-elements/local-navigation-02.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,7 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-page-header campl-section-page">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column12">
@@ -166,6 +174,10 @@
 			</div>
 		</div>	
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/local-navigation-03.html
+++ b/components/core-elements/local-navigation-03.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,7 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-page-header campl-sub-section-page">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column12">
@@ -170,6 +178,10 @@
 			</div>
 		</div>	
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/local-navigation-05.html
+++ b/components/core-elements/local-navigation-05.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,7 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-page-header campl-sub-section-page">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column12">
@@ -169,8 +177,11 @@
 			</div>
 		</div>	
 	</div>
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/local-navigation.html
+++ b/components/core-elements/local-navigation.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,7 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-page-header campl-sub-section-page">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column12">
@@ -276,7 +284,11 @@
 			</div>
 		</div>
 	</div>
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/page-header.html
+++ b/components/core-elements/page-header.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 <div class="campl-row campl-content">
 	<div class="campl-wrap clearfix">
@@ -433,13 +441,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
-	
 
-	
-	
-	
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/page-types/full-width-page.html
+++ b/components/core-elements/page-types/full-width-page.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-global-navigation">
@@ -114,6 +123,11 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript"  src="../../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript"  src="../../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/page-types/homepage.html
+++ b/components/core-elements/page-types/homepage.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-homepage-header">
 		<div class="campl-wrap clearfix">	
@@ -129,8 +137,10 @@
 			</div>
 		</div>
 	</div>
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 	
 	<script type="text/javascript" src="../../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript"  src="../../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/page-types/section-landing.html
+++ b/components/core-elements/page-types/section-landing.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-global-navigation">
@@ -126,6 +135,11 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript"  src="../../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript"  src="../../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/page-types/sub-section-with-left-nav.html
+++ b/components/core-elements/page-types/sub-section-with-left-nav.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-global-navigation">
@@ -219,6 +228,11 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript"  src="../../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript"  src="../../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/page-types/sub-section-without-left-nav.html
+++ b/components/core-elements/page-types/sub-section-without-left-nav.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-global-navigation">
@@ -199,6 +208,11 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript"  src="../../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript"  src="../../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/page-types/sub-section-without-right-col.html
+++ b/components/core-elements/page-types/sub-section-without-right-col.html
@@ -1,13 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
-
-
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -29,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-global-navigation">
@@ -212,6 +219,11 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript"  src="../../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript"  src="../../../javascripts/libs/modernizr.js"></script>

--- a/components/core-elements/print-sampler.html
+++ b/components/core-elements/print-sampler.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
@@ -1252,6 +1261,9 @@
 			</div>
 		</div>
 
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/theme-1.html
+++ b/components/core-elements/theme-1.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-1">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 
@@ -693,6 +702,10 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/theme-2.html
+++ b/components/core-elements/theme-2.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-2">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 
@@ -693,6 +702,10 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/theme-3.html
+++ b/components/core-elements/theme-3.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-3">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 
@@ -694,6 +703,10 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/theme-4.html
+++ b/components/core-elements/theme-4.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-4">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 
@@ -695,6 +704,9 @@
 	</div>
 	<!-- .campl-global-footer ends -->
 
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/theme-5.html
+++ b/components/core-elements/theme-5.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-5">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 
@@ -694,6 +703,10 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/theme-6.html
+++ b/components/core-elements/theme-6.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-6">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 
@@ -694,6 +703,10 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/core-elements/typography.html
+++ b/components/core-elements/typography.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,7 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-2">
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-page-header">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column12">
@@ -137,6 +145,11 @@
 			</div>
 		</div>	
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/index.html
+++ b/components/index.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="styleguide">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
@@ -91,6 +100,11 @@
 			</div>
 		</div>	
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/a-z-navigation.html
+++ b/components/inpage-components/a-z-navigation.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
-  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="">
@@ -27,6 +26,16 @@
 	<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-page-header">
 		<div class="campl-wrap clearfix">
@@ -143,6 +152,10 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/inpage-components/calendar.html
+++ b/components/inpage-components/calendar.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
@@ -102,7 +110,9 @@
 		</div>
 	</div>
 
-
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/inpage-components/co-branding.html
+++ b/components/inpage-components/co-branding.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-page-header">
 		<div class="campl-wrap clearfix">
@@ -86,8 +94,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/contextual-search.html
+++ b/components/inpage-components/contextual-search.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-page-header">
 		<div class="campl-wrap clearfix">
@@ -96,7 +104,11 @@
 			</div>
 		</div>
 	</div>
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/date-01.html
+++ b/components/inpage-components/date-01.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,11 +26,27 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">	
 			<p>Event name 01</p>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/date-02.html
+++ b/components/inpage-components/date-02.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,11 +25,27 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">	
 			<p>Event name 02</p>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/date-03.html
+++ b/components/inpage-components/date-03.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,11 +25,27 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">	
 			<p>Event name 03</p>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/homepage-carousel.html
+++ b/components/inpage-components/homepage-carousel.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-1">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 <div class="campl-row campl-page-header">
 	<div class="campl-wrap clearfix">
@@ -132,7 +140,11 @@
 			</div>
 		</div>
 	</div>
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/homepage-teasers.html
+++ b/components/inpage-components/homepage-teasers.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
   <script type="text/javascript"> document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-secondary-content ">
@@ -145,6 +154,11 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/index.html
+++ b/components/inpage-components/index.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="styleguide">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
@@ -111,6 +120,11 @@
 			</div>
 		</div>	
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/listing-item.html
+++ b/components/inpage-components/listing-item.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content" style="background:#fff">
 		<div class="campl-wrap clearfix" >
 			<div class="campl-column12 ">
@@ -395,8 +404,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/news-listing.html
+++ b/components/inpage-components/news-listing.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
@@ -99,7 +107,11 @@
 			</div>
 		</div>
 	</div>
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/notifications.html
+++ b/components/inpage-components/notifications.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content ">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3">
@@ -114,8 +123,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/pagination.html
+++ b/components/inpage-components/pagination.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
@@ -162,12 +170,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
-	
-	
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/partnership-branding.html
+++ b/components/inpage-components/partnership-branding.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,7 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3">
@@ -122,8 +130,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/related-links.html
+++ b/components/inpage-components/related-links.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="">
@@ -27,7 +26,17 @@
 	<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column4">
@@ -85,7 +94,11 @@
 			</div>
 		</div>
 	</div>
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/section-banner.html
+++ b/components/inpage-components/section-banner.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-page-header">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column9 campl-carousel banner  ">
@@ -76,6 +85,10 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/inpage-components/section-carousel.html
+++ b/components/inpage-components/section-carousel.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-page-header">
 		<div class="campl-wrap clearfix">
@@ -114,6 +122,10 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>

--- a/components/inpage-components/social-media.html
+++ b/components/inpage-components/social-media.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,8 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3">
@@ -90,7 +97,11 @@
 			</div>
 		</div>
 	</div>
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/tables.html
+++ b/components/inpage-components/tables.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,7 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
 			<div class="campl-content-container">
@@ -576,7 +584,10 @@
 		</div>
 	</div>
 
-	
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/tabs-pills.html
+++ b/components/inpage-components/tabs-pills.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,16 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-1">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
 
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
@@ -164,8 +172,11 @@
 			</div>
 		</div>
 	</div>
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/teasers.html
+++ b/components/inpage-components/teasers.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
   <script type="text/javascript"> document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column6 campl-main-content">
@@ -246,6 +255,11 @@
 			</div>
 		</div>
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/components/inpage-components/tooltip.html
+++ b/components/inpage-components/tooltip.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-content">
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3">
@@ -77,7 +86,11 @@
 			</div>
 		</div>
 	</div>
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../../javascripts/libs/modernizr.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="">
@@ -26,7 +24,17 @@
 		<script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="styleguide">
-	
+
+	<!--[if lt IE 7]>
+	<div class="lt-ie9 lt-ie8 lt-ie7">
+	<![endif]-->
+	<!--[if IE 7]>
+	<div class="lt-ie9 lt-ie8">
+	<![endif]-->
+	<!--[if IE 8]>
+	<div class="lt-ie9">
+	<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
@@ -138,6 +146,11 @@
 			</div>
 		</div>	
 	</div>
+
+	<!--[if lte IE 8]>
+	</div>
+	<![endif]-->
+
   <script type="text/javascript" src="javascripts/libs/ios-orientationchange-fix.js"></script>	
   <script src="javascripts/libs/jquery-min.js"></script>
   <script src="javascripts/libs/modernizr.js"></script>

--- a/template-variants/a-z-index.html
+++ b/template-variants/a-z-index.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -26,6 +24,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-1">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#nav" class="campl-skipTo" tabindex="1">skip to navigation</a>
 	<a href="#content" class="campl-skipTo" tabindex="2">skip to content</a>
 
@@ -788,7 +797,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/article-page.html
+++ b/template-variants/article-page.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 
@@ -641,6 +650,10 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>

--- a/template-variants/event-landing.html
+++ b/template-variants/event-landing.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 
 </head>
 <body class="campl-theme-1">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 	
@@ -690,7 +699,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/homepage-annotations.html
+++ b/template-variants/homepage-annotations.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,10 +25,19 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
 
-		
-		
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
+
+
 	<div class="campl-row styleguide-notes">
 		<div class="campl-wrap clearfix">
 			<div class="campl-content-container">
@@ -48,7 +55,12 @@
 				</div>
 			</div>
 		</div>
-	</div>	
+	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/homepage.html
+++ b/template-variants/homepage.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-2">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#nav" class="campl-skipTo" tabindex="1">skip to navigation</a>
 	<a href="#content" class="campl-skipTo" tabindex="2">skip to content</a>
 	
@@ -690,8 +699,11 @@
 			</div>
 		</div>	
 	</div>
-	
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/index.html
+++ b/template-variants/index.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -26,6 +24,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<div class="campl-row campl-global-header">
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
@@ -151,6 +160,11 @@
 			</div>
 		</div>	
 	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/login-form.html
+++ b/template-variants/login-form.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#nav" class="campl-skipTo" tabindex="1">skip to navigation</a>
 	<a href="#content" class="campl-skipTo" tabindex="2">skip to content</a>
 
@@ -432,7 +441,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/person-profile-page.html
+++ b/template-variants/person-profile-page.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 	<script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#nav" class="campl-skipTo" tabindex="1">skip to navigation</a>
 	<a href="#content" class="campl-skipTo" tabindex="2">skip to content</a>
 	<div class="campl-row campl-global-header">
@@ -639,7 +648,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/search-results.html
+++ b/template-variants/search-results.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -29,6 +27,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body class="campl-theme-1">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#nav" class="campl-skipTo" tabindex="1">skip to navigation</a>
 	<a href="#content" class="campl-skipTo" tabindex="2">skip to content</a>
 
@@ -610,7 +619,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/section-landing-annotations.html
+++ b/template-variants/section-landing-annotations.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,10 +25,19 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
 
-		
-		
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
+
+
 	<div class="campl-row styleguide-notes">
 		<div class="campl-wrap clearfix">
 			<div class="campl-content-container">
@@ -48,7 +55,12 @@
 				</div>
 			</div>
 		</div>
-	</div>	
+	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/section-landing-static-carousel.html
+++ b/template-variants/section-landing-static-carousel.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 
 </head>
 <body class="campl-theme-3">
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 	
@@ -667,7 +676,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/section-landing.html
+++ b/template-variants/section-landing.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 	
@@ -723,7 +732,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/sub-section-with-left-annotations.html
+++ b/template-variants/sub-section-with-left-annotations.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,10 +25,19 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
-	
 
-		
-		
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
+
+
 	<div class="campl-row styleguide-notes">
 		<div class="campl-wrap clearfix">
 			<div class="campl-content-container">
@@ -48,7 +55,12 @@
 				</div>
 			</div>
 		</div>
-	</div>	
+	</div>
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/sub-section-with-left-navigation.html
+++ b/template-variants/sub-section-with-left-navigation.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -28,6 +26,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 
@@ -657,7 +666,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/sub-section-with-pic-without-right-column.html
+++ b/template-variants/sub-section-with-pic-without-right-column.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 	<div class="campl-row campl-global-header">
@@ -610,6 +619,9 @@
 			</div>	
 		</div>
 
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
 
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>

--- a/template-variants/sub-section-without-left-navigation.html
+++ b/template-variants/sub-section-without-left-navigation.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 	<div class="campl-row campl-global-header">
@@ -628,7 +637,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
-	
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>

--- a/template-variants/sub-section-without-right-column.html
+++ b/template-variants/sub-section-without-right-column.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 
-<!--[if lt IE 7]>      <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>		   <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js"><!--<![endif]-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" class="no-js">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Live style guide</title>
   <meta name="description" content="" />
@@ -27,6 +25,17 @@
 <script type="text/javascript">  document.documentElement.className += " js";</script>
 </head>
 <body>
+
+<!--[if lt IE 7]>
+<div class="lt-ie9 lt-ie8 lt-ie7">
+<![endif]-->
+<!--[if IE 7]>
+<div class="lt-ie9 lt-ie8">
+<![endif]-->
+<!--[if IE 8]>
+<div class="lt-ie9">
+<![endif]-->
+
 	<a href="#primary-nav" class="campl-skipTo">skip to primary navigation</a>
 	<a href="#content" class="campl-skipTo">skip to content</a>
 	<div class="campl-row campl-global-header">
@@ -623,6 +632,11 @@
 		</div>	
 	</div>
 	<!-- .campl-global-footer ends -->
+
+<!--[if lte IE 8]>
+</div>
+<![endif]-->
+
 	<script type="text/javascript" src="../javascripts/libs/ios-orientationchange-fix.js"></script>
   	<script type="text/javascript" src="../javascripts/libs/jquery-min.js"></script>
 	<script type="text/javascript" src="../javascripts/libs/modernizr.js"></script>


### PR DESCRIPTION
The guidance doesn't currently cater for IE's compatibility mode, and triggering it causes the templates to look like the screenshot in #30.

This PR adds `<meta http-equiv="X-UA-Compatible" content="IE=edge">` to every page. Having conditional comments around `<html>`, however, prevents it from working. As a result, I've moved the classes to a conditional `<div>` that wraps the content (I haven't uses the `<body>` as extra attributes there can create a lot of duplication, as seen with using `<html>`). The classes are only used for styling, so they just need to wrap the content. Hopefully I haven't missed any files!

(The server can also be configured to add a `X-UA-Compatible: IE=edge` header (as www.cam.ac.uk does), but this isn't always practical and isn't distributable.)
