### PR TITLE
Check for existence of th before prepending span to trs in mobile view

### DIFF
--- a/javascripts/custom.js
+++ b/javascripts/custom.js
@@ -351,7 +351,9 @@ projectlight.initTables = function(){
 			//need to find all children of the table rows, (and not just table data cells)
 			var $tableCells = $(this).children();
 			$tableCells.each(function (i) {
-				$(this).prepend("<span class='campl-table-heading'>"+headerTextArray[i]+"</span>")
+				if(headerTextArray[i]) {
+					$(this).prepend("<span class='campl-table-heading'>"+headerTextArray[i]+"</span>")
+				}
 			})
 
 		})


### PR DESCRIPTION
projectlight.initTables unconditionally prepends the contents of th
elements to table cells in the mobile view. If the table does does have a
thead.th, the function prints "undefined" in the prepended span for every
element of the table. It would be better to check if headerTextArray is
populated before preprending the span.
