### PR TITLE
Handle image inputs

### DIFF
--- a/stylesheets/full-stylesheet.css
+++ b/stylesheets/full-stylesheet.css
@@ -275,7 +275,8 @@ label { cursor: pointer;  display: block;margin-bottom: 5px; }
 legend { border: 0; padding: 0; white-space: normal;display: block;width: 100%;padding: 0;margin-bottom: 10px; }
 .lt-ie8 legend{margin-left: -7px;}
 
-button, input[type="button"], input[type="reset"], input[type="submit"] { cursor: pointer; -webkit-appearance: button;margin-bottom:5px; }
+button, input[type="button"], input[type="image"], input[type="reset"], input[type="submit"] { cursor: pointer; -webkit-appearance: button;margin-bottom:5px; }
+input[type="image"] { -webkit-appearance: none; }
 .lt-ie8 button, .lt-ie8 input{overflow: visible;zoom:1;margin: 0 2.5px 5px 2.5px}
 button[disabled], input[disabled] { cursor: default;color:#999 }
 button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
@@ -384,7 +385,9 @@ input[type="checkbox"][disabled],
 input[type="radio"][readonly],
 input[type="checkbox"][readonly] {background-color: transparent;}
 
-input[type="submit"],input[type="reset"],input[type="button"],input[type="radio"],input[type="checkbox"] {width: auto;}
+input[type="submit"],input[type="reset"],input[type="button"],input[type="image"],input[type="radio"],input[type="checkbox"] {width: auto;}
+
+input[type="image"] { display: inline; vertical-align: middle; margin-bottom: 5px; }
 
 /* select menus */
 select,


### PR DESCRIPTION
This fixes #66 by making sure `<input type="image">` elements don't received styles meant for the more-usual input types.

So what was:

![image](https://cloud.githubusercontent.com/assets/1784740/4106987/7064ff02-31c1-11e4-807d-9b860858e597.png)

Is now the expected:

![image](https://cloud.githubusercontent.com/assets/1784740/4106989/736cc84c-31c1-11e4-9674-1184b04c7223.png)
