### PR TITLE
Increase global menu breakpoint

### DIFF
--- a/stylesheets/full-stylesheet.css
+++ b/stylesheets/full-stylesheet.css
@@ -1075,7 +1075,7 @@ caption{background:#fff;padding:5px 0}
 @media (min-width: 768px) and (max-width: 1280px) {
 
 }
-@media (max-width: 1000px) {
+@media (max-width: 1023px) {
 	/*Change main nav*/
 	.campl-global-navigation{width:280px}
 	.campl-global-navigation li{width:33%}


### PR DESCRIPTION
#41 tried to fix the global menu popping down on smaller (eg iPad landscape) screen sizes. Turns out one of the breakpoints was too low so it's still happening. This should finally fix it (by changing it to the value used on cam.ac.uk).
