### PR TITLE
Apply borders to table.campl-table-bordered only

### DIFF
--- a/stylesheets/full-stylesheet.css
+++ b/stylesheets/full-stylesheet.css
@@ -1446,8 +1446,7 @@ caption{background:#fff;padding:5px 0}
 .campl-main-content h1,
 .campl-main-content h2 {color:#106470 }
 
-table,
-.campl-table-bordered {border-bottom:2px solid #28828a;}
+table.campl-table-bordered {border-bottom:2px solid #28828a;}
 th{background:#28828a;color:#fff}
 th.campl-alt{background:#fff;color:#28828a}
 .campl-table-striped tbody tr:nth-child(odd) td,
@@ -1507,8 +1506,7 @@ th.campl-alt{background:#fff;color:#28828a}
 .campl-theme-1 .campl-main-content h1,
 .campl-theme-1 .campl-main-content h2 {color:#003e74 }
 
-.campl-theme-1 table,
-.campl-theme-1 .campl-table-bordered {border-bottom:2px solid #0072cf;}
+.campl-theme-1 table.campl-table-bordered {border-bottom:2px solid #0072cf;}
 .campl-theme-1 th{background:#0072cf;color:#fff}
 .campl-theme-1 th.campl-alt{background:#fff;color:#0072cf}
 .campl-theme-1 .campl-table-striped tbody tr:nth-child(odd) td,
@@ -1567,8 +1565,7 @@ th.campl-alt{background:#fff;color:#28828a}
 .campl-theme-2 .campl-main-content h1,
 .campl-theme-2 .campl-main-content h2 {color:#106470 }
 
-.campl-theme-2 table,
-.campl-theme-2 .campl-table-bordered {border-bottom:2px solid #28828a;}
+.campl-theme-2 table.campl-table-bordered {border-bottom:2px solid #28828a;}
 .campl-theme-2 th{background:#28828a;color:#fff}
 .campl-theme-2 th.campl-alt{background:#fff;color:#28828a}
 .campl-theme-2 .campl-table-striped tbody tr:nth-child(odd) td,
@@ -1627,8 +1624,7 @@ th.campl-alt{background:#fff;color:#28828a}
 .campl-theme-3 .campl-main-content h1,
 .campl-theme-3 .campl-main-content h2 {color:#422e5d }
 
-.campl-theme-3 table,
-.campl-theme-3 .campl-table-bordered {border-bottom:2px solid #8f2b8c;}
+.campl-theme-3 table.campl-table-bordered {border-bottom:2px solid #8f2b8c;}
 .campl-theme-3 th{background:#8f2b8c;color:#fff}
 .campl-theme-3 th.campl-alt{background:#fff;color:#8f2b8c}
 .campl-theme-3 .campl-table-striped tbody tr:nth-child(odd) td,
@@ -1687,8 +1683,7 @@ th.campl-alt{background:#fff;color:#28828a}
 .campl-theme-4 .campl-main-content h1,
 .campl-theme-4 .campl-main-content h2 {color:#304220 }
 
-.campl-theme-4 table,
-.campl-theme-4 .campl-table-bordered {border-bottom:2px solid #57831a;}
+.campl-theme-4 table.campl-table-bordered {border-bottom:2px solid #57831a;}
 .campl-theme-4 th{background:#57831a;color:#fff}
 .campl-theme-4 th.campl-alt{background:#fff;color:#57831a}
 .campl-theme-4 .campl-table-striped tbody tr:nth-child(odd) td,
@@ -1746,8 +1741,7 @@ th.campl-alt{background:#fff;color:#28828a}
 .campl-theme-5 .campl-main-content h1,
 .campl-theme-5 .campl-main-content h2 {color:#c44101 }
 
-.campl-theme-5 table,
-.campl-theme-5 .campl-table-bordered {border-bottom:2px solid #df671d;}
+.campl-theme-5 table.campl-table-bordered {border-bottom:2px solid #df671d;}
 .campl-theme-5 th{background:#df671d;color:#fff}
 .campl-theme-5 th.campl-alt{background:#fff;color:#df671d}
 .campl-theme-5 .campl-table-striped tbody tr:nth-child(odd) td,
@@ -1806,8 +1800,7 @@ th.campl-alt{background:#fff;color:#28828a}
 .campl-theme-6 .campl-main-content h1,
 .campl-theme-6 .campl-main-content h2 {color:#851735 }
 
-.campl-theme-6 table,
-.campl-theme-6 .campl-table-bordered {border-bottom:2px solid #d61746;}
+.campl-theme-6 table.campl-table-bordered {border-bottom:2px solid #d61746;}
 .campl-theme-6 th{background:#d61746;color:#fff}
 .campl-theme-6 th.campl-alt{background:#fff;color:#d61746}
 .campl-theme-6 .campl-table-striped tbody tr:nth-child(odd) td,
@@ -1864,8 +1857,7 @@ th.campl-alt{background:#fff;color:#28828a}
 .campl-theme-7 .campl-main-content h1,
 .campl-theme-7 .campl-main-content h2 {color:#404040 }
 
-.campl-theme-7 table,
-.campl-theme-7 .campl-table-bordered {border-bottom:2px solid #8C8989;}
+.campl-theme-7 table.campl-table-bordered {border-bottom:2px solid #8C8989;}
 .campl-theme-7 th{background:#8C8989;color:#fff}
 .campl-theme-7 th.campl-alt{background:#fff;color:#8C8989}
 .campl-theme-7 .campl-table-striped tbody tr:nth-child(odd) td,


### PR DESCRIPTION
The existing rule applied a bottom border to all tables regardless of class, which looked unintentional.

Fixes #63, #81