### PR TITLE
Fix for issue #70: hover on the final item in a top menu line

### DIFF
--- a/stylesheets/full-stylesheet.css
+++ b/stylesheets/full-stylesheet.css
@@ -1462,7 +1462,7 @@ th.campl-alt{background:#fff;color:#28828a}
 .campl-local-navigation a:hover,
 .campl-local-navigation a:active{background-color:#1e7680;}
 .campl-local-navigation a.campl-selected{background:#28828a}
-.campl-local-navigation li.campl-hover a{background-color:#003a41;border-bottom:0}
+.campl-local-navigation li.campl-hover a{background-color:#003a41;border-bottom-width:1px; border-bottom-style:solid;}
 .campl-local-navigation li.campl-sub li a{background-color: #003a41;border-right:0; }
 .campl-local-navigation li.campl-sub li li a{border-bottom:1px solid #0c5963;}
 .campl-local-navigation li.campl-sub li:last-child a {border-bottom:0;}


### PR DESCRIPTION
Without this fix, “if there are too many main menu items for the
current screen width, and the menu spills to two lines, a hover on the
final item on the top line causes the following item to disappear.” #70