### PR TITLE
change height="38px;" to height="38"

### DIFF
--- a/components/core-elements/footer.html
+++ b/components/core-elements/footer.html
@@ -155,7 +155,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/components/core-elements/global-header.html
+++ b/components/core-elements/global-header.html
@@ -40,7 +40,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">

--- a/components/core-elements/homepage-header.html
+++ b/components/core-elements/homepage-header.html
@@ -40,7 +40,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="/" class="campl-main-logo">
-					<img alt=""  src="../../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt=""  src="../../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation">

--- a/components/core-elements/index.html
+++ b/components/core-elements/index.html
@@ -41,7 +41,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
 				<a href="/project-light" class="campl-main-logo">
-					<img alt=""  src="../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt=""  src="../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 				</a>
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation">
 					<li>

--- a/components/core-elements/page-types/sub-section-with-left-nav.html
+++ b/components/core-elements/page-types/sub-section-with-left-nav.html
@@ -135,7 +135,7 @@
 			<div class="campl-column3">
 				<div class="campl-content-container">
 					<div class="campl-footer-logo">
-						<img alt=""  src="../../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+						<img alt=""  src="../../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					</div>
 					<p>&#169; 2015 University of Cambridge, <br />
 						The old schools, Trinity Lane, <br />

--- a/components/core-elements/page-types/sub-section-without-left-nav.html
+++ b/components/core-elements/page-types/sub-section-without-left-nav.html
@@ -112,7 +112,7 @@
 			<div class="campl-column3">
 				<div class="campl-content-container">
 					<div class="campl-footer-logo">
-						<img alt=""  src="../../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+						<img alt=""  src="../../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					</div>
 					<p>&#169; 2015 University of Cambridge, <br />
 						The old schools, Trinity Lane, <br />

--- a/components/core-elements/page-types/sub-section-without-right-col.html
+++ b/components/core-elements/page-types/sub-section-without-right-col.html
@@ -127,7 +127,7 @@
 			<div class="campl-column3">
 				<div class="campl-content-container">
 					<div class="campl-footer-logo">
-						<img alt=""  src="../../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+						<img alt=""  src="../../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					</div>
 					<p>&#169; 2015 University of Cambridge, <br />
 						The old schools, Trinity Lane, <br />

--- a/components/core-elements/theme-1.html
+++ b/components/core-elements/theme-1.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -601,7 +601,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/components/core-elements/theme-2.html
+++ b/components/core-elements/theme-2.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -601,7 +601,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/components/core-elements/theme-3.html
+++ b/components/core-elements/theme-3.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -602,7 +602,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/components/core-elements/theme-4.html
+++ b/components/core-elements/theme-4.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -602,7 +602,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/components/core-elements/theme-5.html
+++ b/components/core-elements/theme-5.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -602,7 +602,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/components/core-elements/theme-6.html
+++ b/components/core-elements/theme-6.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -602,7 +602,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/components/index.html
+++ b/components/index.html
@@ -40,7 +40,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
 				<a href="/project-light" class="campl-main-logo">
-					<img alt=""  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt=""  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 				</a>
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation">
 					<li>

--- a/components/inpage-components/index.html
+++ b/components/inpage-components/index.html
@@ -41,7 +41,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
 				<a href="/project-light" class="campl-main-logo">
-					<img alt=""  src="../../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt=""  src="../../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 				</a>
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation">
 					<li>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
 				<a href="/project-light" class="campl-main-logo">
-					<img alt=""  src="images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt=""  src="images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 				</a>
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation">
 					<li>

--- a/template-variants/a-z-index.html
+++ b/template-variants/a-z-index.html
@@ -42,7 +42,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -696,7 +696,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/article-page.html
+++ b/template-variants/article-page.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -549,7 +549,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/event-landing.html
+++ b/template-variants/event-landing.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -598,7 +598,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/homepage.html
+++ b/template-variants/homepage.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="/" class="campl-main-logo">
-					<img alt=""  src="../images/interface/main-logo-small.svg" height="38px;"/>
+					<img alt=""  src="../images/interface/main-logo-small.svg" height="38"/>
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation" id="primary-nav">
@@ -259,7 +259,7 @@
 			<div class="campl-column7">
 				<div class="campl-content-container clearfix">
 					<a href="/" class="campl-main-logo">
-						<img alt=""  src="../images/interface/main-logo-homepage.svg" height="61px;"/>
+						<img alt=""  src="../images/interface/main-logo-homepage.svg" height="61"/>
 					</a>
 				</div>
 			</div>
@@ -609,7 +609,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt=""  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt=""  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
                             <li>

--- a/template-variants/index.html
+++ b/template-variants/index.html
@@ -39,7 +39,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-column9" id="global-header-controls">
 				<a href="/project-light" class="campl-main-logo">
-					<img alt=""  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt=""  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 				</a>
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation">
 					<li>

--- a/template-variants/login-form.html
+++ b/template-variants/login-form.html
@@ -43,7 +43,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -340,7 +340,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/person-profile-page.html
+++ b/template-variants/person-profile-page.html
@@ -43,7 +43,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -547,7 +547,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/search-results.html
+++ b/template-variants/search-results.html
@@ -45,7 +45,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -518,7 +518,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/section-landing-static-carousel.html
+++ b/template-variants/section-landing-static-carousel.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -575,7 +575,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/section-landing.html
+++ b/template-variants/section-landing.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -634,7 +634,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/sub-section-with-left-navigation.html
+++ b/template-variants/sub-section-with-left-navigation.html
@@ -44,7 +44,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -568,7 +568,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/sub-section-with-pic-without-right-column.html
+++ b/template-variants/sub-section-with-pic-without-right-column.html
@@ -42,7 +42,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="/" class="campl-main-logo">
-					<img alt=""  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt=""  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix" id="primary-nav">
@@ -524,7 +524,7 @@
 			<div class="campl-wrap clearfix">
 				<div class="campl-column3 campl-footer-navigation">
 					<div class="campl-content-container campl-footer-logo">
-						<img alt=""  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+						<img alt=""  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 						<p>&#169; 2012 University of Cambridge, <br />
 							The old schools, Trinity Lane, <br />
 							Cambridge CB2 1TN, UK</p>

--- a/template-variants/sub-section-without-left-navigation.html
+++ b/template-variants/sub-section-without-left-navigation.html
@@ -42,7 +42,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -536,7 +536,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>

--- a/template-variants/sub-section-without-right-column.html
+++ b/template-variants/sub-section-without-right-column.html
@@ -42,7 +42,7 @@
 		<div class="campl-wrap clearfix">	
 			<div class="campl-header-container campl-column8" id="global-header-controls">
 				<a href="http://www.cam.ac.uk" class="campl-main-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" />
 				</a>
 
 				<ul class="campl-unstyled-list campl-horizontal-navigation campl-global-navigation clearfix">
@@ -531,7 +531,7 @@
 		<div class="campl-wrap clearfix">
 			<div class="campl-column3 campl-footer-navigation">
 				<div class="campl-content-container campl-footer-logo">
-					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38px;" class="campl-scale-with-grid" />
+					<img alt="University of Cambridge"  src="../images/interface/main-logo-small.svg" height="38" class="campl-scale-with-grid" />
 					<p>&#169; 2015 University of Cambridge</p>
 						<ul class="campl-unstyled-list campl-global-footer-links">
 							<li>


### PR DESCRIPTION
The height and width HTML attributes “must have values that are valid non-negative integers.” Unlike the CSS attributes of the same name, they cannot have a unit suffix such as “px”.

https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes

Tool: perl -pi -E 's/(width|height)="(\d+)px;"/$1="$2"/' *.html */*.html ...

(Note that this is just a syntax fix. It doesn't yet address the fact that this HTML attribute is actually overridden in the global footer by the CSS class `campl-scale-with-grid`, which actually sets `height: auto`. CSS usually overrides HTML presentational attributes.)
